### PR TITLE
Add opt-in D3D11 → D3D12 GPU video output backend (Windows)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,7 @@ dependencies = [
  "godot",
  "printf",
  "ringbuf",
+ "windows",
 ]
 
 [[package]]
@@ -418,6 +419,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +534,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,21 @@ godot = {version = "0.3.5", features = ["experimental-threads", "register-docs",
 printf = "0.1.0"
 ringbuf = "0.4.8"
 
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.61", optional = true, features = [
+  "Win32_Foundation",
+  "Win32_Graphics_Direct3D",
+  "Win32_Graphics_Direct3D11",
+  "Win32_Graphics_Direct3D12",
+  "Win32_Graphics_Dxgi",
+  "Win32_Graphics_Dxgi_Common",
+  "Win32_Security",
+  "Win32_System_Threading",
+] }
+
+[features]
+default = []
+gpu = ["dep:windows"]
+
 [build-dependencies]
 bindgen = "0.72.1"

--- a/demo/main.tscn
+++ b/demo/main.tscn
@@ -28,6 +28,7 @@ func _process(_delta: float) -> void:
 	%Time.text = \"time: {0} / {1}\".format([get_time(), get_length()])
 	var pos = get_position()
 	%Position.text = \"position: %.6f\" % pos
+	%GPUOutput.text = \"gpu output: \" + str(is_gpu_output_active())
 	if not dragging:
 		%HSlider.value = pos
 
@@ -236,6 +237,11 @@ text = "position:"
 unique_name_in_owner = true
 layout_mode = 2
 text = "state:"
+
+[node name="GPUOutput" type="Label" parent="VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "gpu output:"
 
 [node name="Statics" type="Button" parent="VBoxContainer"]
 layout_mode = 2

--- a/demo/main.tscn
+++ b/demo/main.tscn
@@ -134,6 +134,7 @@ func _on_file_dialog_file_selected(path: String) -> void:
 
 [node name="VLCMediaPlayer" type="VLCMediaPlayer"]
 media = ExtResource("1_ig7tw")
+autoplay = true
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0

--- a/demo/tests/adapter_match.gd
+++ b/demo/tests/adapter_match.gd
@@ -1,0 +1,37 @@
+extends SceneTree
+
+# Under --rendering-driver d3d12, the LUID Godot reports for its D3D12
+# device and the LUID DXGI reports for the matching adapter must be equal
+# and nonzero — that's how the GPU backend picks the right adapter for the
+# D3D11 device it hands to libvlc.
+
+func _init() -> void:
+	var player := VLCMediaPlayer.new()
+	var luids: Dictionary = player._debug_get_adapter_luids()
+	player.queue_free()
+
+	if luids.has("error"):
+		push_error("adapter_match: probe returned error: %s" % luids["error"])
+		quit(1)
+		return
+
+	if not luids.has("godot_luid") or not luids.has("d3d11_luid"):
+		push_error("adapter_match: missing keys in %s" % str(luids))
+		quit(1)
+		return
+
+	var godot_luid: int = luids["godot_luid"]
+	var d3d11_luid: int = luids["d3d11_luid"]
+
+	if godot_luid == 0 or d3d11_luid == 0:
+		push_error("adapter_match: zero LUID (godot=%d d3d11=%d)" % [godot_luid, d3d11_luid])
+		quit(1)
+		return
+
+	if godot_luid != d3d11_luid:
+		push_error("adapter_match: LUID mismatch (godot=%d d3d11=%d)" % [godot_luid, d3d11_luid])
+		quit(1)
+		return
+
+	print("adapter_match OK: godot_luid=0x%x d3d11_luid=0x%x" % [godot_luid, d3d11_luid])
+	quit(0)

--- a/demo/tests/gpu_render.gd
+++ b/demo/tests/gpu_render.gd
@@ -1,0 +1,38 @@
+extends SceneTree
+
+# With force_hardware=true under --rendering-driver d3d12, the per-frame
+# importer must drain the SPSC mailbox, allocate a Godot RD destination,
+# and run private_queue.copy_and_sync() each frame. Asserts frames_copied
+# is positive after libvlc has had time to start signalling its fence.
+
+func _init() -> void:
+	var player := VLCMediaPlayer.new()
+	player.force_hardware = true
+	player.media = VLCMedia.load_from_file(ProjectSettings.globalize_path("res://test.mp4"))
+	player.autoplay = true
+	root.add_child(player)
+
+	# Setup → register → libvlc decode start → update_output_cb →
+	# first swap_cb (= first fence signal) → first copy_and_sync.
+	# 120 frames at 60fps = ~2s, generous for libvlc to spin up.
+	for _i in 120:
+		await process_frame
+
+	if not player._debug_gpu_active():
+		push_error("gpu_render FAIL: GPU init never succeeded")
+		quit(1)
+		return
+
+	var copied: int = player._debug_frames_copied()
+	if copied < 1:
+		push_error("gpu_render FAIL: frames_copied=%d after 120 frames (importer never ran a copy)" % copied)
+		quit(1)
+		return
+
+	var avg: Color = player._debug_dst_pixel_avg()
+	var cb: Vector3i = player._debug_callback_counts()
+	print("gpu_render OK: frames_copied=%d, dst avg RGBA=(%.3f, %.3f, %.3f, %.3f), update_output=%d swap=%d make_current=%d" % [copied, avg.r, avg.g, avg.b, avg.a, cb.x, cb.y, cb.z])
+	player.stop_async()
+	for _i in 30:
+		await process_frame
+	quit(0)

--- a/demo/tests/gpu_setup.gd
+++ b/demo/tests/gpu_setup.gd
@@ -1,0 +1,35 @@
+extends SceneTree
+
+# With force_hardware=true under --rendering-driver d3d12, the GPU backend
+# should initialize and libvlc's update_output_cb should fire once libvlc
+# starts decoding — evidenced by an event in the mailbox carrying the
+# clip's resolution.
+
+func _init() -> void:
+	var player := VLCMediaPlayer.new()
+	player.force_hardware = true
+	player.media = VLCMedia.load_from_file(ProjectSettings.globalize_path("res://test.mp4"))
+	player.autoplay = true
+	root.add_child(player)
+
+	for _i in 60:
+		await process_frame
+
+	if not player._debug_gpu_active():
+		push_error("gpu_setup FAIL: _debug_gpu_active() returned false (GPU init failed; see godot_error log above)")
+		quit(1)
+		return
+
+	var size: Vector2i = player._debug_pop_gpu_event()
+	if size.x <= 0 or size.y <= 0:
+		push_error("gpu_setup FAIL: no event in mailbox after 60 frames (update_output_cb never fired?)")
+		quit(1)
+		return
+
+	print("gpu_setup OK: GPU backend active, update_output_cb fired with %dx%d" % [size.x, size.y])
+	# stop_async + drain a few frames so libvlc's render thread isn't mid-flight
+	# during SceneTree teardown.
+	player.stop_async()
+	for _i in 30:
+		await process_frame
+	quit(0)

--- a/demo/tests/wrong_driver.gd
+++ b/demo/tests/wrong_driver.gd
@@ -1,0 +1,23 @@
+extends SceneTree
+
+# Under a non-D3D12 rendering driver (e.g. --rendering-driver vulkan), the
+# adapter-LUID probe must return a structured error and not crash.
+
+func _init() -> void:
+	var player := VLCMediaPlayer.new()
+	var luids: Dictionary = player._debug_get_adapter_luids()
+	player.queue_free()
+
+	if not luids.has("error"):
+		push_error("wrong_driver: expected 'error' key, got %s" % str(luids))
+		quit(1)
+		return
+
+	var msg: String = luids["error"]
+	if not msg.contains("d3d12"):
+		push_error("wrong_driver: error string missing 'd3d12' marker: %s" % msg)
+		quit(1)
+		return
+
+	print("wrong_driver OK: %s" % msg)
+	quit(0)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.91.0"

--- a/src/vlc_media_player.rs
+++ b/src/vlc_media_player.rs
@@ -328,6 +328,22 @@ impl VlcMediaPlayer {
         self.texture.clone().upcast()
     }
 
+    /// Whether the GPU output backend is currently driving this player.
+    /// Reflects the *actual* state after `try_init_gpu_backend()`: if
+    /// `force_hardware` was set but init failed and we fell back to the
+    /// software path, this returns `false`.
+    #[cfg(all(feature = "gpu", windows))]
+    #[func]
+    fn is_gpu_output_active(&self) -> bool {
+        self.gpu_backend.is_some()
+    }
+
+    #[cfg(not(all(feature = "gpu", windows)))]
+    #[func]
+    fn is_gpu_output_active(&self) -> bool {
+        false
+    }
+
     /// Pop the pending GPU output event from the mailbox, returning the
     /// texture's `(width, height)` or `(0, 0)` if empty. Drains the mailbox.
     #[cfg(all(feature = "gpu", windows))]

--- a/src/vlc_media_player.rs
+++ b/src/vlc_media_player.rs
@@ -19,10 +19,14 @@
 
 mod internal_audio_stream;
 pub mod internal_audio_stream_playback;
+mod software_video;
+
+#[cfg(all(feature = "gpu", windows))]
+mod gpu_d3d11;
 
 use std::{
     ffi::{c_char, c_int, c_uint, c_void},
-    ptr::{self, slice_from_raw_parts},
+    ptr::slice_from_raw_parts,
     sync::mpsc,
 };
 
@@ -37,13 +41,12 @@ use crate::{
 use godot::{
     classes::{
         control::{LayoutPreset, LayoutPresetMode},
-        image,
         native::AudioFrame,
         node::InternalMode,
         notify::ControlNotification,
         texture_rect::{ExpandMode, StretchMode as TextureRectStretchMode},
         AudioServer, AudioStream, AudioStreamPlayer, Control, IControl, Image, ImageTexture,
-        Texture2D, TextureRect,
+        RenderingServer, Texture2D, TextureRect,
     },
     obj::NewAlloc,
     prelude::*,
@@ -84,6 +87,13 @@ struct VlcMediaPlayer {
     media: Option<Gd<VlcMedia>>,
     #[export]
     autoplay: bool,
+    /// Opt into the GPU output backend (libvlc renders into a D3D11 shared
+    /// texture, our private D3D12 queue copies it into a Godot RD texture
+    /// each frame). Requires Windows + `--rendering-driver d3d12`; on any
+    /// prerequisite failure the player logs an error and falls back to the
+    /// software path. Default `false` keeps the CPU pipeline.
+    #[export]
+    force_hardware: bool,
     #[export]
     #[var(get, set=set_stretch_mode)]
     stretch_mode: StretchMode,
@@ -104,6 +114,19 @@ struct VlcMediaPlayer {
     video_rx: mpsc::Receiver<(bool, Gd<Image>)>,
     audio_prod: Box<(HeapProd<AudioFrame>, Gd<AudioStreamPlayer>)>,
     audio_player: Gd<AudioStreamPlayer>,
+    /// libvlc-side `Arc<Backend>` ref; the libvlc-side ref is held via the
+    /// opaque pointer passed to `libvlc_video_set_output_callbacks`. Both
+    /// drop when the player is destroyed (libvlc's via `cleanup_cb`).
+    #[cfg(all(feature = "gpu", windows))]
+    gpu_backend: Option<std::sync::Arc<gpu_d3d11::output_callbacks::Backend>>,
+    #[cfg(all(feature = "gpu", windows))]
+    gpu_mailbox: Option<std::sync::Arc<gpu_d3d11::event_queue::EventMailbox>>,
+    /// Per-frame importer captured by the `frame_pre_draw` Callable below;
+    /// disconnecting that Callable on Drop releases the ref.
+    #[cfg(all(feature = "gpu", windows))]
+    gpu_importer: Option<std::sync::Arc<gpu_d3d11::importer::ImporterTask>>,
+    #[cfg(all(feature = "gpu", windows))]
+    gpu_frame_callable: Option<Callable>,
 }
 
 #[godot_api]
@@ -129,6 +152,7 @@ impl IControl for VlcMediaPlayer {
             base,
             media: None,
             autoplay: false,
+            force_hardware: false,
             stretch_mode: StretchMode::KeepAspectCenterd,
             volume_db: 0.0,
             mix_target: MixTarget::Stereo,
@@ -141,6 +165,14 @@ impl IControl for VlcMediaPlayer {
             video_rx,
             audio_prod,
             audio_player,
+            #[cfg(all(feature = "gpu", windows))]
+            gpu_backend: None,
+            #[cfg(all(feature = "gpu", windows))]
+            gpu_mailbox: None,
+            #[cfg(all(feature = "gpu", windows))]
+            gpu_importer: None,
+            #[cfg(all(feature = "gpu", windows))]
+            gpu_frame_callable: None,
         }
     }
 
@@ -192,6 +224,14 @@ impl IControl for VlcMediaPlayer {
 
 impl Drop for VlcMediaPlayer {
     fn drop(&mut self) {
+        // Disconnect the per-frame callable BEFORE releasing the player —
+        // an in-flight frame_pre_draw must not run against a half-torn
+        // ImporterTask.
+        #[cfg(all(feature = "gpu", windows))]
+        if let Some(c) = self.gpu_frame_callable.take() {
+            RenderingServer::singleton()
+                .disconnect(&StringName::from("frame_pre_draw"), &c);
+        }
         unsafe {
             libvlc_media_player_release(self.player_ptr);
         }
@@ -286,6 +326,122 @@ impl VlcMediaPlayer {
     #[func]
     fn get_texture(&self) -> Gd<Texture2D> {
         self.texture.clone().upcast()
+    }
+
+    /// Pop the pending GPU output event from the mailbox, returning the
+    /// texture's `(width, height)` or `(0, 0)` if empty. Drains the mailbox.
+    #[cfg(all(feature = "gpu", windows))]
+    #[func]
+    fn _debug_pop_gpu_event(&self) -> Vector2i {
+        let Some(mailbox) = self.gpu_mailbox.as_ref() else {
+            return Vector2i::new(0, 0);
+        };
+        match mailbox.take() {
+            Some(e) => Vector2i::new(e.width as i32, e.height as i32),
+            None => Vector2i::new(0, 0),
+        }
+    }
+
+    /// True when the GPU backend successfully initialized for this player.
+    #[cfg(all(feature = "gpu", windows))]
+    #[func]
+    fn _debug_gpu_active(&self) -> bool {
+        self.gpu_backend.is_some()
+    }
+
+    /// Number of per-frame `copy_and_sync` invocations completed by the
+    /// importer. 0 if the GPU backend isn't active.
+    #[cfg(all(feature = "gpu", windows))]
+    #[func]
+    fn _debug_frames_copied(&self) -> i64 {
+        match &self.gpu_importer {
+            None => 0,
+            Some(t) => t
+                .frames_copied
+                .load(std::sync::atomic::Ordering::SeqCst) as i64,
+        }
+    }
+
+    /// libvlc callback hit counts as `(update_output, swap, make_current)`.
+    #[cfg(all(feature = "gpu", windows))]
+    #[func]
+    fn _debug_callback_counts(&self) -> Vector3i {
+        let Some(b) = self.gpu_backend.as_ref() else {
+            return Vector3i::new(0, 0, 0);
+        };
+        Vector3i::new(
+            b.update_output_calls.load(std::sync::atomic::Ordering::SeqCst) as i32,
+            b.swap_calls.load(std::sync::atomic::Ordering::SeqCst) as i32,
+            b.make_current_calls.load(std::sync::atomic::Ordering::SeqCst) as i32,
+        )
+    }
+
+    /// Average RGBA of the GPU destination texture, read back via
+    /// `RenderingDevice::texture_get_data`. `Color(0,0,0,0)` when GPU isn't
+    /// active or no destination is bound.
+    #[cfg(all(feature = "gpu", windows))]
+    #[func]
+    fn _debug_dst_pixel_avg(&self) -> Color {
+        let Some(importer) = self.gpu_importer.as_ref() else {
+            return Color::from_rgba(0.0, 0.0, 0.0, 0.0);
+        };
+        let rid = match importer.current_dst_rid() {
+            Some(r) => r,
+            None => return Color::from_rgba(0.0, 0.0, 0.0, 0.0),
+        };
+        let mut rd = match RenderingServer::singleton().get_rendering_device() {
+            Some(rd) => rd,
+            None => return Color::from_rgba(0.0, 0.0, 0.0, 0.0),
+        };
+        let bytes = rd.texture_get_data(rid, 0);
+        if bytes.is_empty() {
+            return Color::from_rgba(0.0, 0.0, 0.0, 0.0);
+        }
+        let mut sums = [0u64; 4];
+        let mut count: u64 = 0;
+        for chunk in bytes.as_slice().chunks_exact(4) {
+            sums[0] += chunk[0] as u64;
+            sums[1] += chunk[1] as u64;
+            sums[2] += chunk[2] as u64;
+            sums[3] += chunk[3] as u64;
+            count += 1;
+        }
+        if count == 0 {
+            return Color::from_rgba(0.0, 0.0, 0.0, 0.0);
+        }
+        let denom = count as f32 * 255.0;
+        Color::from_rgba(
+            sums[0] as f32 / denom,
+            sums[1] as f32 / denom,
+            sums[2] as f32 / denom,
+            sums[3] as f32 / denom,
+        )
+    }
+
+    /// Returns `{godot_luid, d3d11_luid}` when the rendering driver is D3D12
+    /// and the LUIDs match, or `{error}` otherwise.
+    #[cfg(all(feature = "gpu", windows))]
+    #[func]
+    fn _debug_get_adapter_luids(&self) -> Dictionary {
+        use gpu_d3d11::adapter::{dxgi_adapter_luid_for, godot_d3d12_luid};
+        let mut dict = Dictionary::new();
+        match godot_d3d12_luid() {
+            Err(e) => {
+                let _ = dict.insert("error", e.to_string());
+            }
+            Ok(godot_luid) => {
+                let _ = dict.insert("godot_luid", godot_luid);
+                match dxgi_adapter_luid_for(godot_luid) {
+                    Ok(d3d11_luid) => {
+                        let _ = dict.insert("d3d11_luid", d3d11_luid);
+                    }
+                    Err(e) => {
+                        let _ = dict.insert("error", e.to_string());
+                    }
+                }
+            }
+        }
+        dict
     }
 
     /// Can this media player be paused?
@@ -678,22 +834,111 @@ impl VlcMediaPlayer {
         Some(self.media.as_ref()?.bind().media_ptr)
     }
 
+    /// Bring up the GPU output backend. `true` if it activated; `false`
+    /// means the caller should register the software callbacks instead.
+    /// Failures are logged via `godot_error!`; no panics.
+    #[cfg(all(feature = "gpu", windows))]
+    fn try_init_gpu_backend(&mut self) -> bool {
+        if !self.force_hardware {
+            return false;
+        }
+        use std::sync::Arc;
+        let (_adapter, d3d11) = match gpu_d3d11::adapter::create_d3d11_device_for_godot() {
+            Ok(v) => v,
+            Err(e) => {
+                godot_error!("godot-vlc: GPU init failed (adapter/D3D11 device): {e}");
+                return false;
+            }
+        };
+        let mailbox = Arc::new(gpu_d3d11::event_queue::EventMailbox::new());
+        let backend = match gpu_d3d11::output_callbacks::Backend::new(
+            d3d11.device,
+            d3d11.context,
+            mailbox.clone(),
+        ) {
+            Ok(b) => Arc::new(b),
+            Err(e) => {
+                godot_error!("godot-vlc: GPU init failed (Backend::new): {e}");
+                return false;
+            }
+        };
+        let importer = match gpu_d3d11::importer::ImporterTask::create(backend.clone()) {
+            Ok(t) => t,
+            Err(e) => {
+                godot_error!("godot-vlc: GPU init failed (ImporterTask::create): {e}");
+                return false;
+            }
+        };
+        // Swap the texture_rect's bound texture to the GPU-path Texture2Drd.
+        {
+            let drd = importer
+                .texture_2drd
+                .lock()
+                .expect("texture_2drd poisoned")
+                .clone();
+            self.texture_rect.set_texture(&drd.upcast::<Texture2D>());
+        }
+        // Per-frame import + copy: frame_pre_draw → call_on_render_thread.
+        let frame_task = importer.clone();
+        let frame_callable = Callable::from_sync_fn("godot_vlc_per_frame", move |_args| {
+            let task = frame_task.clone();
+            let render_callable =
+                Callable::from_sync_fn("godot_vlc_per_frame_render", move |_args| {
+                    gpu_d3d11::importer::run_frame(&task);
+                    Ok(Variant::nil())
+                });
+            RenderingServer::singleton().call_on_render_thread(&render_callable);
+            Ok(Variant::nil())
+        });
+        // Untyped Object::connect: godot-rust 0.3.5's typed-signal accessor
+        // takes a closure with no disconnect path; we need a Callable handle
+        // to disconnect on Drop.
+        RenderingServer::singleton()
+            .connect(&StringName::from("frame_pre_draw"), &frame_callable);
+        if let Err(e) = gpu_d3d11::output_callbacks::register(self.player_ptr, backend.clone()) {
+            godot_error!("godot-vlc: GPU init failed ({e})");
+            RenderingServer::singleton()
+                .disconnect(&StringName::from("frame_pre_draw"), &frame_callable);
+            return false;
+        }
+        self.gpu_backend = Some(backend);
+        self.gpu_mailbox = Some(mailbox);
+        self.gpu_importer = Some(importer);
+        self.gpu_frame_callable = Some(frame_callable);
+        godot_print!("godot-vlc: GPU backend active (D3D11→D3D12 GPU-copy)");
+        true
+    }
+
+    /// Stub for non-GPU builds. Always returns false so the software path
+    /// runs.
+    #[cfg(not(all(feature = "gpu", windows)))]
+    fn try_init_gpu_backend(&mut self) -> bool {
+        false
+    }
+
     fn register_player_callbacks(&mut self) {
         unsafe {
             let self_ptr = self.self_gd.as_mut().unwrap().as_mut() as *mut _;
 
-            libvlc_video_set_callbacks(
-                self.player_ptr,
-                Some(video_lock_callback),
-                Some(video_unlock_callback),
-                Some(video_display_callback),
-                self.video_tx.as_mut() as *mut _ as *mut c_void,
-            );
-            libvlc_video_set_format_callbacks(
-                self.player_ptr,
-                Some(video_format_callback),
-                Some(video_cleanup_callback),
-            );
+            // The GPU output-callbacks API and the software callbacks API
+            // are mutually exclusive at the libvlc level: register one or
+            // the other, never both. On any GPU init failure we fall
+            // through to the software path.
+            let gpu_active = self.try_init_gpu_backend();
+            if !gpu_active {
+                libvlc_video_set_callbacks(
+                    self.player_ptr,
+                    Some(software_video::video_lock_callback),
+                    Some(software_video::video_unlock_callback),
+                    Some(software_video::video_display_callback),
+                    self.video_tx.as_mut() as *mut _ as *mut c_void,
+                );
+                libvlc_video_set_format_callbacks(
+                    self.player_ptr,
+                    Some(software_video::video_format_callback),
+                    Some(software_video::video_cleanup_callback),
+                );
+            }
             libvlc_audio_set_callbacks(
                 self.player_ptr,
                 Some(audio_play_callback),
@@ -829,93 +1074,6 @@ impl VlcMediaPlayer {
             );
         }
     }
-}
-
-unsafe extern "C" fn video_lock_callback(
-    opaque: *mut c_void,
-    planes: *mut *mut c_void,
-) -> *mut c_void {
-    let (_tx, _img, buffer) = (opaque
-        as *mut (
-            *mut mpsc::Sender<(bool, Gd<Image>)>,
-            Gd<Image>,
-            PackedByteArray,
-        ))
-        .as_mut()
-        .unwrap();
-    let buffer_ptr = buffer.as_mut_slice().as_mut_ptr();
-    *planes = buffer_ptr as *mut c_void;
-    ptr::null_mut()
-}
-
-unsafe extern "C" fn video_unlock_callback(
-    opaque: *mut c_void,
-    _picture: *mut c_void,
-    _planes: *const *mut c_void,
-) {
-    let (_tx, img, buffer) = (opaque
-        as *mut (
-            *mut mpsc::Sender<(bool, Gd<Image>)>,
-            Gd<Image>,
-            PackedByteArray,
-        ))
-        .as_mut()
-        .unwrap();
-    let width = img.get_width();
-    let height = img.get_height();
-    let format = img.get_format();
-    img.set_data(width, height, false, format, buffer);
-}
-
-unsafe extern "C" fn video_display_callback(opaque: *mut c_void, _picture: *mut c_void) {
-    let (tx, img, _buffer) = (opaque
-        as *mut (
-            *mut mpsc::Sender<(bool, Gd<Image>)>,
-            Gd<Image>,
-            PackedByteArray,
-        ))
-        .as_mut()
-        .unwrap();
-    _ = tx
-        .as_mut()
-        .unwrap()
-        .send((false, img.duplicate().unwrap().cast()));
-}
-
-unsafe extern "C" fn video_format_callback(
-    opaque: *mut *mut c_void,
-    chroma: *mut c_char,
-    width: *mut c_uint,
-    height: *mut c_uint,
-    pitches: *mut c_uint,
-    lines: *mut c_uint,
-) -> c_uint {
-    let tx: *mut mpsc::Sender<(bool, Gd<Image>)> = *opaque as *mut mpsc::Sender<(bool, Gd<Image>)>;
-    let img = match Image::create_empty(*width as i32, *height as i32, false, image::Format::RGB8) {
-        Some(img) => img,
-        None => {
-            return 0;
-        }
-    };
-    let buffer = img.get_data();
-    chroma.copy_from(c"RV24".as_ptr(), 5);
-    *pitches = *width * 3;
-    *lines = *height;
-    if tx.as_mut().unwrap().send((true, img.clone())).is_err() {
-        return 0;
-    }
-    *opaque = Box::into_raw(Box::new((tx, img, buffer))) as *mut c_void;
-    1
-}
-unsafe extern "C" fn video_cleanup_callback(opaque: *mut c_void) {
-    let (_tx, _img, _buffer) = *Box::from_raw(
-        opaque
-            as *mut (
-                *mut mpsc::Sender<(bool, Gd<Image>)>,
-                Gd<Image>,
-                PackedByteArray,
-            ),
-    );
 }
 
 unsafe extern "C" fn audio_play_callback(

--- a/src/vlc_media_player/gpu_d3d11/adapter.rs
+++ b/src/vlc_media_player/gpu_d3d11/adapter.rs
@@ -1,0 +1,288 @@
+//! Adapter LUID matching (Godot's D3D12 device → matching DXGI adapter)
+//! and `D3D11CreateDevice` on that adapter for the GPU backend.
+
+use std::ffi::c_void;
+use std::fmt;
+
+use godot::classes::rendering_device::DriverResource;
+use godot::classes::RenderingServer;
+use godot::prelude::*;
+
+use windows::core::Interface;
+use windows::Win32::Foundation::{HMODULE, LUID};
+use windows::Win32::Graphics::Direct3D::{
+    D3D_DRIVER_TYPE_UNKNOWN, D3D_FEATURE_LEVEL_11_0, D3D_FEATURE_LEVEL_11_1,
+};
+use windows::Win32::Graphics::Direct3D11::{
+    D3D11CreateDevice, ID3D11Device, ID3D11DeviceContext, D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+    D3D11_CREATE_DEVICE_VIDEO_SUPPORT, D3D11_SDK_VERSION,
+};
+use windows::Win32::Graphics::Direct3D12::ID3D12Device;
+use windows::Win32::Graphics::Dxgi::{CreateDXGIFactory1, IDXGIAdapter1, IDXGIFactory1};
+
+#[derive(Debug)]
+pub enum AdapterError {
+    NotD3D12(String),
+    NoRenderingDevice,
+    NoLogicalDevice,
+    DxgiFactory(String),
+    LuidNotFound(i64),
+    D3D11CreateFailed(String),
+}
+
+impl fmt::Display for AdapterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotD3D12(api) => write!(
+                f,
+                "godot-vlc: GPU backend requires --rendering-driver d3d12 (rendering API: {api})"
+            ),
+            Self::NoRenderingDevice => {
+                write!(f, "godot-vlc: RenderingServer has no RenderingDevice")
+            }
+            Self::NoLogicalDevice => write!(
+                f,
+                "godot-vlc: RenderingDevice did not yield a D3D12 logical device handle"
+            ),
+            Self::DxgiFactory(s) => write!(f, "godot-vlc: CreateDXGIFactory1 failed: {s}"),
+            Self::LuidNotFound(luid) => {
+                write!(f, "godot-vlc: no DXGI adapter matched LUID {luid:#x}")
+            }
+            Self::D3D11CreateFailed(s) => write!(f, "godot-vlc: D3D11CreateDevice failed: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for AdapterError {}
+
+/// Pack a Win32 `LUID` into a signed 64-bit value for stable comparison.
+pub fn luid_to_i64(luid: LUID) -> i64 {
+    (((luid.HighPart as u32 as u64) << 32) | (luid.LowPart as u64)) as i64
+}
+
+/// Abstraction over adapter enumeration so `find_adapter_by_luid` is unit
+/// testable without a live DXGI factory.
+pub trait AdapterEnumerator {
+    type Adapter;
+    fn enumerate(&self) -> Vec<(i64, Self::Adapter)>;
+}
+
+pub fn find_adapter_by_luid<E: AdapterEnumerator>(
+    enumerator: &E,
+    target_luid: i64,
+) -> Option<E::Adapter> {
+    enumerator
+        .enumerate()
+        .into_iter()
+        .find_map(|(luid, a)| if luid == target_luid { Some(a) } else { None })
+}
+
+pub struct DxgiAdapterEnumerator;
+
+impl AdapterEnumerator for DxgiAdapterEnumerator {
+    type Adapter = IDXGIAdapter1;
+
+    fn enumerate(&self) -> Vec<(i64, IDXGIAdapter1)> {
+        unsafe {
+            let factory: IDXGIFactory1 = match CreateDXGIFactory1() {
+                Ok(f) => f,
+                Err(_) => return Vec::new(),
+            };
+            let mut out = Vec::new();
+            let mut idx = 0u32;
+            while let Ok(adapter) = factory.EnumAdapters1(idx) {
+                if let Ok(desc) = adapter.GetDesc1() {
+                    out.push((luid_to_i64(desc.AdapterLuid), adapter));
+                }
+                idx += 1;
+            }
+            out
+        }
+    }
+}
+
+/// True when Godot's video adapter API version looks like a D3D12 feature
+/// level (`<digits>_<digits>`, e.g. `12_0`). Vulkan reports `X.Y.Z`,
+/// OpenGL reports text, dummy reports empty.
+pub fn is_d3d12_api_string(api: &str) -> bool {
+    let mut parts = api.split('_');
+    let lhs = parts.next();
+    let rhs = parts.next();
+    if parts.next().is_some() {
+        return false;
+    }
+    matches!(
+        (lhs, rhs),
+        (Some(a), Some(b)) if !a.is_empty()
+            && !b.is_empty()
+            && a.chars().all(|c| c.is_ascii_digit())
+            && b.chars().all(|c| c.is_ascii_digit())
+    )
+}
+
+/// LUID of Godot's D3D12 logical device. Errors if the rendering driver
+/// isn't D3D12 or no rendering device is available.
+pub fn godot_d3d12_luid() -> Result<i64, AdapterError> {
+    let rs = RenderingServer::singleton();
+    let api = rs.get_video_adapter_api_version().to_string();
+    if !is_d3d12_api_string(&api) {
+        return Err(AdapterError::NotD3D12(api));
+    }
+
+    let mut rd = rs
+        .get_rendering_device()
+        .ok_or(AdapterError::NoRenderingDevice)?;
+
+    let handle = rd.get_driver_resource(DriverResource::LOGICAL_DEVICE, Rid::Invalid, 0);
+    if handle == 0 {
+        return Err(AdapterError::NoLogicalDevice);
+    }
+
+    let raw = handle as *mut c_void;
+    let device = unsafe {
+        ID3D12Device::from_raw_borrowed(&raw).ok_or(AdapterError::NoLogicalDevice)?
+    };
+    let luid = unsafe { device.GetAdapterLuid() };
+    Ok(luid_to_i64(luid))
+}
+
+/// Find the DXGI adapter matching `target_luid` and return its
+/// self-reported LUID. Used to round-trip-verify the Godot ↔ DXGI match.
+pub fn dxgi_adapter_luid_for(target_luid: i64) -> Result<i64, AdapterError> {
+    let enumerator = DxgiAdapterEnumerator;
+    let adapter = find_adapter_by_luid(&enumerator, target_luid)
+        .ok_or(AdapterError::LuidNotFound(target_luid))?;
+    let desc = unsafe { adapter.GetDesc1().map_err(|e| AdapterError::DxgiFactory(e.message())) }?;
+    Ok(luid_to_i64(desc.AdapterLuid))
+}
+
+/// D3D11 device + immediate context paired together.
+pub struct CreatedD3D11 {
+    pub device: ID3D11Device,
+    pub context: ID3D11DeviceContext,
+}
+
+/// Create a D3D11 device on `adapter` with the flags libvlc's D3D11 output
+/// engine and hardware-decode pipeline need (`BGRA_SUPPORT | VIDEO_SUPPORT`,
+/// plus thread protection enabled on the device's immediate context).
+pub fn create_d3d11_device(adapter: &IDXGIAdapter1) -> Result<CreatedD3D11, AdapterError> {
+    let feature_levels = [D3D_FEATURE_LEVEL_11_1, D3D_FEATURE_LEVEL_11_0];
+    let mut device: Option<ID3D11Device> = None;
+    let mut context: Option<ID3D11DeviceContext> = None;
+    let mut flags = D3D11_CREATE_DEVICE_BGRA_SUPPORT | D3D11_CREATE_DEVICE_VIDEO_SUPPORT;
+    if std::env::var_os("GODOT_VLC_D3D11_DEBUG").is_some() {
+        flags |= windows::Win32::Graphics::Direct3D11::D3D11_CREATE_DEVICE_DEBUG;
+    }
+
+    let hr = unsafe {
+        D3D11CreateDevice(
+            adapter,
+            D3D_DRIVER_TYPE_UNKNOWN,
+            HMODULE::default(),
+            flags,
+            Some(&feature_levels),
+            D3D11_SDK_VERSION,
+            Some(&mut device),
+            None,
+            Some(&mut context),
+        )
+    };
+    hr.map_err(|e| AdapterError::D3D11CreateFailed(e.message()))?;
+
+    let device = device.ok_or_else(|| {
+        AdapterError::D3D11CreateFailed("D3D11CreateDevice succeeded but device is null".into())
+    })?;
+    let context = context.ok_or_else(|| {
+        AdapterError::D3D11CreateFailed("D3D11CreateDevice succeeded but context is null".into())
+    })?;
+    // libvlc's d3d11 output engine requires multithread-protected device.
+    let multithread: windows::Win32::Graphics::Direct3D11::ID3D11Multithread = device
+        .cast()
+        .map_err(|e| AdapterError::D3D11CreateFailed(format!("ID3D11Multithread cast: {}", e.message())))?;
+    unsafe {
+        let _ = multithread.SetMultithreadProtected(true);
+    }
+    Ok(CreatedD3D11 { device, context })
+}
+
+/// Full chain: read Godot's D3D12 device LUID, find the matching DXGI
+/// adapter, and create a D3D11 device on it.
+pub fn create_d3d11_device_for_godot() -> Result<(IDXGIAdapter1, CreatedD3D11), AdapterError> {
+    let luid = godot_d3d12_luid()?;
+    let adapter = find_adapter_by_luid(&DxgiAdapterEnumerator, luid)
+        .ok_or(AdapterError::LuidNotFound(luid))?;
+    let d3d11 = create_d3d11_device(&adapter)?;
+    Ok((adapter, d3d11))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FakeEnumerator(Vec<(i64, &'static str)>);
+    impl AdapterEnumerator for FakeEnumerator {
+        type Adapter = &'static str;
+        fn enumerate(&self) -> Vec<(i64, &'static str)> {
+            self.0.clone()
+        }
+    }
+
+    #[test]
+    fn match_first() {
+        let e = FakeEnumerator(vec![(0x1234, "first"), (0x5678, "second")]);
+        assert_eq!(find_adapter_by_luid(&e, 0x1234), Some("first"));
+    }
+
+    #[test]
+    fn match_last() {
+        let e = FakeEnumerator(vec![(0x1234, "first"), (0x5678, "last")]);
+        assert_eq!(find_adapter_by_luid(&e, 0x5678), Some("last"));
+    }
+
+    #[test]
+    fn no_match() {
+        let e = FakeEnumerator(vec![(0x1234, "a"), (0x5678, "b")]);
+        assert_eq!(find_adapter_by_luid(&e, 0x9999), None);
+    }
+
+    #[test]
+    fn duplicate_luid_returns_first() {
+        let e = FakeEnumerator(vec![(0x1234, "first"), (0x1234, "second")]);
+        assert_eq!(find_adapter_by_luid(&e, 0x1234), Some("first"));
+    }
+
+    #[test]
+    fn empty_enumerator() {
+        let e = FakeEnumerator(vec![]);
+        assert_eq!(find_adapter_by_luid(&e, 0x1234), None);
+    }
+
+    #[test]
+    fn d3d12_api_string_accepts_feature_levels() {
+        assert!(is_d3d12_api_string("12_0"));
+        assert!(is_d3d12_api_string("12_1"));
+        assert!(is_d3d12_api_string("11_0"));
+    }
+
+    #[test]
+    fn d3d12_api_string_rejects_other_drivers() {
+        assert!(!is_d3d12_api_string(""));
+        assert!(!is_d3d12_api_string("1.3.250"));
+        assert!(!is_d3d12_api_string("OpenGL ES 3.0"));
+        assert!(!is_d3d12_api_string("12_0_0"));
+        assert!(!is_d3d12_api_string("12_"));
+        assert!(!is_d3d12_api_string("_0"));
+        assert!(!is_d3d12_api_string("ab_cd"));
+    }
+
+    #[test]
+    fn luid_pack_roundtrip() {
+        let luid = LUID {
+            LowPart: 0xDEAD_BEEF,
+            HighPart: 0x1234_5678,
+        };
+        let packed = luid_to_i64(luid);
+        assert_eq!(packed as u64 & 0xFFFF_FFFF, 0xDEAD_BEEF);
+        assert_eq!((packed as u64) >> 32, 0x1234_5678);
+    }
+}

--- a/src/vlc_media_player/gpu_d3d11/event_queue.rs
+++ b/src/vlc_media_player/gpu_d3d11/event_queue.rs
@@ -1,0 +1,142 @@
+//! 1-slot mailbox carrying VLC's "new output texture" events from libvlc's
+//! render thread to the Godot render-thread importer. Latest-wins shape:
+//! push replaces, the previous event's NT handle closes on drop.
+
+use std::sync::Mutex;
+
+use windows::Win32::Foundation::{CloseHandle, HANDLE};
+
+/// Emitted by `update_output_cb` on every (re-)allocation. Closes the NT
+/// handle on drop so a never-consumed event can't leak.
+pub struct OutputEvent {
+    pub handle: HANDLE,
+    pub width: u32,
+    pub height: u32,
+}
+
+unsafe impl Send for OutputEvent {}
+
+impl OutputEvent {
+    /// Take the handle without closing it. Caller is then responsible for
+    /// closing it (or letting the dropped event close it).
+    #[allow(dead_code)]
+    pub fn into_parts(mut self) -> (HANDLE, u32, u32) {
+        let handle = std::mem::replace(&mut self.handle, HANDLE::default());
+        (handle, self.width, self.height)
+    }
+}
+
+impl Drop for OutputEvent {
+    fn drop(&mut self) {
+        if !self.handle.is_invalid() {
+            unsafe { _ = CloseHandle(self.handle) };
+        }
+    }
+}
+
+pub struct EventMailbox {
+    slot: Mutex<Option<OutputEvent>>,
+}
+
+impl EventMailbox {
+    pub fn new() -> Self {
+        Self {
+            slot: Mutex::new(None),
+        }
+    }
+
+    /// Replace any pending event. The prior event (if any) is dropped,
+    /// closing its NT handle.
+    pub fn push(&self, e: OutputEvent) {
+        let _prev = self
+            .slot
+            .lock()
+            .expect("event mailbox poisoned")
+            .replace(e);
+    }
+
+    pub fn take(&self) -> Option<OutputEvent> {
+        self.slot
+            .lock()
+            .expect("event mailbox poisoned")
+            .take()
+    }
+}
+
+impl Default for EventMailbox {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn fake_event(width: u32, height: u32) -> OutputEvent {
+        OutputEvent {
+            handle: HANDLE::default(),
+            width,
+            height,
+        }
+    }
+
+    #[test]
+    fn empty_mailbox_returns_none() {
+        let mb = EventMailbox::new();
+        assert!(mb.take().is_none());
+    }
+
+    #[test]
+    fn push_then_take_round_trip() {
+        let mb = EventMailbox::new();
+        mb.push(fake_event(1920, 1080));
+        let got = mb.take().expect("event should be present");
+        assert_eq!(got.width, 1920);
+        assert_eq!(got.height, 1080);
+    }
+
+    #[test]
+    fn second_push_supersedes_first() {
+        let mb = EventMailbox::new();
+        mb.push(fake_event(640, 480));
+        mb.push(fake_event(1280, 720));
+        let got = mb.take().expect("event should be present");
+        assert_eq!((got.width, got.height), (1280, 720));
+        assert!(mb.take().is_none());
+    }
+
+    #[test]
+    fn take_after_drain_is_empty_again() {
+        let mb = EventMailbox::new();
+        mb.push(fake_event(800, 600));
+        let _ = mb.take();
+        assert!(mb.take().is_none());
+        mb.push(fake_event(1024, 768));
+        let got = mb.take().expect("re-push should be observable");
+        assert_eq!((got.width, got.height), (1024, 768));
+    }
+
+    #[test]
+    fn into_parts_extracts_handle() {
+        let e = fake_event(100, 200);
+        let (handle, w, h) = e.into_parts();
+        assert!(handle.is_invalid());
+        assert_eq!((w, h), (100, 200));
+    }
+
+    #[test]
+    fn cross_thread_send() {
+        let mb = Arc::new(EventMailbox::new());
+        let producer = {
+            let mb = mb.clone();
+            std::thread::spawn(move || {
+                mb.push(fake_event(42, 7));
+            })
+        };
+        producer.join().expect("producer thread");
+        let got = mb.take().expect("event delivered across threads");
+        assert_eq!((got.width, got.height), (42, 7));
+    }
+}

--- a/src/vlc_media_player/gpu_d3d11/event_queue.rs
+++ b/src/vlc_media_player/gpu_d3d11/event_queue.rs
@@ -21,7 +21,7 @@ impl OutputEvent {
     /// closing it (or letting the dropped event close it).
     #[allow(dead_code)]
     pub fn into_parts(mut self) -> (HANDLE, u32, u32) {
-        let handle = std::mem::replace(&mut self.handle, HANDLE::default());
+        let handle = std::mem::take(&mut self.handle);
         (handle, self.width, self.height)
     }
 }

--- a/src/vlc_media_player/gpu_d3d11/importer.rs
+++ b/src/vlc_media_player/gpu_d3d11/importer.rs
@@ -1,0 +1,207 @@
+//! Per-frame import + GPU-copy orchestrator. Runs on the Godot render
+//! thread (scheduled from `frame_pre_draw` via `call_on_render_thread`).
+//! Drains the mailbox for resize events, opens the new D3D11 shared
+//! texture on Godot's D3D12 device, allocates a Godot-RD destination, and
+//! runs `PrivateQueue::copy_and_sync` for the frame.
+
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc, Mutex,
+};
+
+use godot::classes::rendering_device::{DataFormat, TextureSamples, TextureType, TextureUsageBits};
+use godot::classes::{RdTextureFormat, RdTextureView, RenderingServer, Texture2Drd};
+use godot::obj::NewGd;
+use godot::prelude::{Gd, Rid};
+
+use windows::Win32::Graphics::Direct3D12::{ID3D12Device, ID3D12Fence, ID3D12Resource};
+
+use super::output_callbacks::Backend;
+use super::private_queue::PrivateQueue;
+use super::rd_import::{godot_d3d12_device, godot_rd_texture_native, open_shared_fence, open_shared_texture, ImportError};
+
+#[derive(Debug)]
+pub enum ImporterError {
+    Import(ImportError),
+    PrivateQueue(super::private_queue::PrivateQueueError),
+    AllocateRdDest,
+}
+
+impl std::fmt::Display for ImporterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Import(e) => write!(f, "{e}"),
+            Self::PrivateQueue(e) => write!(f, "{e}"),
+            Self::AllocateRdDest => write!(
+                f,
+                "godot-vlc: RenderingDevice::texture_create returned invalid Rid"
+            ),
+        }
+    }
+}
+
+impl From<ImportError> for ImporterError {
+    fn from(e: ImportError) -> Self {
+        Self::Import(e)
+    }
+}
+impl From<super::private_queue::PrivateQueueError> for ImporterError {
+    fn from(e: super::private_queue::PrivateQueueError) -> Self {
+        Self::PrivateQueue(e)
+    }
+}
+
+/// The currently imported D3D11 shared texture (as an `ID3D12Resource`)
+/// paired with the Godot-RD destination it copies into.
+struct CurrentImport {
+    d3d12_src: ID3D12Resource,
+    dst_rid: Rid,
+    d3d12_dst: ID3D12Resource,
+}
+
+/// Owned by `VLCMediaPlayer` and captured by the per-frame Callable. The
+/// player disconnects the signal on Drop, releasing the captured Arc.
+pub struct ImporterTask {
+    backend: Arc<Backend>,
+    d3d12_device: ID3D12Device,
+    d3d12_fence: ID3D12Fence,
+    private_queue: PrivateQueue,
+    /// Bound to the Godot-RD destination's Rid. Sampled by Godot.
+    pub texture_2drd: Mutex<Gd<Texture2Drd>>,
+    current: Mutex<Option<CurrentImport>>,
+    pub frames_copied: AtomicU64,
+}
+
+// SAFETY: The COM interfaces are reference-counted and thread-safe at the
+// API level. Mutex covers the mutable state. Gd<Texture2Drd> requires the
+// godot crate's experimental-threads feature, which is enabled in Cargo.toml.
+unsafe impl Send for ImporterTask {}
+unsafe impl Sync for ImporterTask {}
+
+impl ImporterTask {
+    /// RID of the current GPU destination, if any.
+    pub fn current_dst_rid(&self) -> Option<Rid> {
+        self.current
+            .lock()
+            .expect("importer current poisoned")
+            .as_ref()
+            .map(|c| c.dst_rid)
+    }
+
+    pub fn create(backend: Arc<Backend>) -> Result<Arc<Self>, ImporterError> {
+        let d3d12_device = godot_d3d12_device()?;
+        let d3d12_fence = open_shared_fence(&d3d12_device, backend.fence_shared_handle())?;
+        let private_queue = PrivateQueue::create(&d3d12_device)?;
+        let texture_2drd = Texture2Drd::new_gd();
+        Ok(Arc::new(Self {
+            backend,
+            d3d12_device,
+            d3d12_fence,
+            private_queue,
+            texture_2drd: Mutex::new(texture_2drd),
+            current: Mutex::new(None),
+            frames_copied: AtomicU64::new(0),
+        }))
+    }
+}
+
+/// One frame's work on the Godot render thread. Drains the mailbox to
+/// pick up resize events, then copies the latest fence value into the
+/// destination.
+pub fn run_frame(task: &ImporterTask) {
+    if let Err(e) = try_run_frame(task) {
+        eprintln!("godot-vlc: importer run_frame failed: {e}");
+    }
+}
+
+fn try_run_frame(task: &ImporterTask) -> Result<(), ImporterError> {
+    if let Some(event) = task.backend.mailbox.take() {
+        rebuild_current(task, event.handle, event.width, event.height)?;
+    }
+
+    let current_lock = task.current.lock().expect("importer current poisoned");
+    let Some(current) = current_lock.as_ref() else {
+        return Ok(());
+    };
+    let latest = task.backend.fence.current();
+    if latest == 0 {
+        // libvlc hasn't signaled a frame yet; waiting on 0 would block forever.
+        return Ok(());
+    }
+    task.private_queue.copy_and_sync(
+        &task.d3d12_fence,
+        latest,
+        &current.d3d12_src,
+        &current.d3d12_dst,
+    )?;
+    task.frames_copied.fetch_add(1, Ordering::SeqCst);
+    Ok(())
+}
+
+fn rebuild_current(
+    task: &ImporterTask,
+    handle: windows::Win32::Foundation::HANDLE,
+    width: u32,
+    height: u32,
+) -> Result<(), ImporterError> {
+    let d3d12_src = open_shared_texture(&task.d3d12_device, handle)?;
+    let new_rid = create_sampled_texture(width, height)
+        .ok_or(ImporterError::AllocateRdDest)?;
+    let d3d12_dst = godot_rd_texture_native(new_rid)?;
+
+    task.texture_2drd
+        .lock()
+        .expect("texture_2drd poisoned")
+        .set_texture_rd_rid(new_rid);
+
+    let mut slot = task.current.lock().expect("importer current poisoned");
+    if let Some(old) = slot.take() {
+        free_rid(old.dst_rid);
+    }
+    *slot = Some(CurrentImport {
+        d3d12_src,
+        dst_rid: new_rid,
+        d3d12_dst,
+    });
+    Ok(())
+}
+
+fn create_sampled_texture(width: u32, height: u32) -> Option<Rid> {
+    let mut rd = RenderingServer::singleton().get_rendering_device()?;
+    let mut format = RdTextureFormat::new_gd();
+    format.set_format(DataFormat::R8G8B8A8_UNORM);
+    format.set_width(width);
+    format.set_height(height);
+    format.set_depth(1);
+    format.set_array_layers(1);
+    format.set_mipmaps(1);
+    format.set_texture_type(TextureType::TYPE_2D);
+    format.set_samples(TextureSamples::SAMPLES_1);
+    let usage = TextureUsageBits::SAMPLING_BIT
+        | TextureUsageBits::CAN_COPY_TO_BIT
+        | TextureUsageBits::CAN_COPY_FROM_BIT;
+    format.set_usage_bits(usage);
+    let view = RdTextureView::new_gd();
+    let rid = rd.texture_create(&format, &view);
+    if !rid.is_valid() {
+        return None;
+    }
+    Some(rid)
+}
+
+fn free_rid(rid: Rid) {
+    if !rid.is_valid() {
+        return;
+    }
+    if let Some(mut rd) = RenderingServer::singleton().get_rendering_device() {
+        rd.free_rid(rid);
+    }
+}
+
+impl Drop for ImporterTask {
+    fn drop(&mut self) {
+        if let Some(current) = self.current.lock().expect("importer current poisoned").take() {
+            free_rid(current.dst_rid);
+        }
+    }
+}

--- a/src/vlc_media_player/gpu_d3d11/mod.rs
+++ b/src/vlc_media_player/gpu_d3d11/mod.rs
@@ -1,0 +1,9 @@
+//! D3D11 GPU output backend. Compiled only when `feature = "gpu"` and `cfg(windows)`.
+
+pub mod adapter;
+pub mod event_queue;
+pub mod importer;
+pub mod output_callbacks;
+pub mod private_queue;
+pub mod rd_import;
+pub mod shared_texture;

--- a/src/vlc_media_player/gpu_d3d11/output_callbacks.rs
+++ b/src/vlc_media_player/gpu_d3d11/output_callbacks.rs
@@ -1,0 +1,325 @@
+//! `libvlc_video_engine_d3d11` output callbacks. The `Backend` owns the
+//! D3D11 device + immediate context + shared fence + current output
+//! texture; the opaque pointer libvlc threads through every callback is
+//! `Arc::into_raw(backend)` and `cleanup_cb` reclaims it via `Arc::from_raw`.
+//! All callbacks run on libvlc's render thread.
+
+use std::ffi::c_void;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use windows::core::Interface;
+use windows::Win32::Foundation::{GENERIC_ALL, HANDLE};
+use windows::Win32::Graphics::Direct3D11::{
+    ID3D11Device, ID3D11DeviceContext, ID3D11RenderTargetView, ID3D11Resource, ID3D11Texture2D,
+    D3D11_BIND_RENDER_TARGET, D3D11_BIND_SHADER_RESOURCE, D3D11_RESOURCE_MISC_SHARED,
+    D3D11_RESOURCE_MISC_SHARED_NTHANDLE, D3D11_TEXTURE2D_DESC, D3D11_USAGE_DEFAULT,
+};
+use windows::Win32::Graphics::Dxgi::Common::{DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_SAMPLE_DESC};
+use windows::Win32::Graphics::Dxgi::IDXGIResource1;
+
+use crate::vlc::{
+    libvlc_media_player_t, libvlc_video_color_primaries_t_libvlc_video_primaries_BT709,
+    libvlc_video_color_space_t_libvlc_video_colorspace_BT709,
+    libvlc_video_engine_t_libvlc_video_engine_d3d11, libvlc_video_orient_t_libvlc_video_orient_top_left,
+    libvlc_video_output_cfg_t, libvlc_video_render_cfg_t, libvlc_video_set_output_callbacks,
+    libvlc_video_setup_device_cfg_t, libvlc_video_setup_device_info_t,
+    libvlc_video_transfer_func_t_libvlc_video_transfer_func_SRGB,
+};
+
+use super::event_queue::{EventMailbox, OutputEvent};
+use super::shared_texture::SharedFence;
+
+/// `DXGI_FORMAT_R8G8B8A8_UNORM` as a raw `c_int` for libvlc's output cfg
+/// (`windows-rs` types it as `DXGI_FORMAT(28)`).
+const DXGI_FORMAT_R8G8B8A8_UNORM_RAW: i32 = 28;
+
+/// State shared between libvlc's render thread (callbacks) and the Godot
+/// render-thread importer (per-frame copy). Both sides hold `Arc<Backend>`.
+pub struct Backend {
+    pub device: ID3D11Device,
+    pub context: ID3D11DeviceContext,
+    pub fence: SharedFence,
+    pub mailbox: Arc<EventMailbox>,
+    pub(crate) current: Mutex<Option<CurrentOutput>>,
+    pub update_output_calls: AtomicU64,
+    pub swap_calls: AtomicU64,
+    pub make_current_calls: AtomicU64,
+}
+
+unsafe impl Send for Backend {}
+unsafe impl Sync for Backend {}
+
+/// Both fields are read only by libvlc through the COM pointers; we hold
+/// them so the underlying objects stay alive for the output's lifetime.
+#[allow(dead_code)]
+pub(crate) struct CurrentOutput {
+    texture: ID3D11Texture2D,
+    rtv: ID3D11RenderTargetView,
+}
+
+#[derive(Debug)]
+pub enum CallbackError {
+    CreateTexture(String),
+    QueryDxgiResource(String),
+    CreateSharedHandle(String),
+    CreateRtv(String),
+    CreateFence(super::shared_texture::SharedError),
+    SetOutputCallbacksFailed,
+}
+
+impl std::fmt::Display for CallbackError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CreateTexture(s) => write!(f, "godot-vlc: CreateTexture2D failed: {s}"),
+            Self::QueryDxgiResource(s) => {
+                write!(f, "godot-vlc: cast to IDXGIResource1 failed: {s}")
+            }
+            Self::CreateSharedHandle(s) => {
+                write!(f, "godot-vlc: CreateSharedHandle failed: {s}")
+            }
+            Self::CreateRtv(s) => write!(f, "godot-vlc: CreateRenderTargetView failed: {s}"),
+            Self::CreateFence(e) => write!(f, "{e}"),
+            Self::SetOutputCallbacksFailed => {
+                write!(f, "godot-vlc: libvlc_video_set_output_callbacks returned false")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CallbackError {}
+
+impl Backend {
+    pub fn new(
+        device: ID3D11Device,
+        context: ID3D11DeviceContext,
+        mailbox: Arc<EventMailbox>,
+    ) -> Result<Self, CallbackError> {
+        let fence = SharedFence::create(&device).map_err(CallbackError::CreateFence)?;
+        Ok(Self {
+            device,
+            context,
+            fence,
+            mailbox,
+            current: Mutex::new(None),
+            update_output_calls: AtomicU64::new(0),
+            swap_calls: AtomicU64::new(0),
+            make_current_calls: AtomicU64::new(0),
+        })
+    }
+
+    /// Shared NT handle of the producer fence; the importer opens it once
+    /// on its D3D12 device to get an `ID3D12Fence`.
+    pub fn fence_shared_handle(&self) -> HANDLE {
+        self.fence.shared_handle
+    }
+
+    /// Allocate a new shared D3D11 texture + RTV, mint a fresh NT handle,
+    /// push the handle to the mailbox, and install as the current output.
+    /// Called from `update_output_cb` on libvlc's render thread.
+    fn rebuild_current_output(
+        &self,
+        width: u32,
+        height: u32,
+    ) -> Result<(), CallbackError> {
+        let desc = D3D11_TEXTURE2D_DESC {
+            Width: width,
+            Height: height,
+            MipLevels: 1,
+            ArraySize: 1,
+            Format: DXGI_FORMAT_R8G8B8A8_UNORM,
+            SampleDesc: DXGI_SAMPLE_DESC {
+                Count: 1,
+                Quality: 0,
+            },
+            Usage: D3D11_USAGE_DEFAULT,
+            BindFlags: (D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE).0 as u32,
+            CPUAccessFlags: 0,
+            // SHARED_NTHANDLE must be paired with SHARED or SHARED_KEYEDMUTEX;
+            // SHARED + shared fence is enough for our cross-API sync.
+            MiscFlags: (D3D11_RESOURCE_MISC_SHARED_NTHANDLE | D3D11_RESOURCE_MISC_SHARED).0 as u32,
+        };
+
+        let mut texture: Option<ID3D11Texture2D> = None;
+        unsafe { self.device.CreateTexture2D(&desc, None, Some(&mut texture)) }
+            .map_err(|e| CallbackError::CreateTexture(e.message()))?;
+        let texture = texture
+            .ok_or_else(|| CallbackError::CreateTexture("null texture out-param".into()))?;
+
+        let dxgi_resource: IDXGIResource1 = texture
+            .cast()
+            .map_err(|e| CallbackError::QueryDxgiResource(e.message()))?;
+        let handle = unsafe { dxgi_resource.CreateSharedHandle(None, GENERIC_ALL.0, None) }
+            .map_err(|e| CallbackError::CreateSharedHandle(e.message()))?;
+
+        let mut rtv: Option<ID3D11RenderTargetView> = None;
+        let resource: ID3D11Resource = texture
+            .cast()
+            .map_err(|e| CallbackError::QueryDxgiResource(e.message()))?;
+        unsafe {
+            self.device
+                .CreateRenderTargetView(&resource, None, Some(&mut rtv))
+        }
+        .map_err(|e| CallbackError::CreateRtv(e.message()))?;
+        let rtv = rtv.ok_or_else(|| CallbackError::CreateRtv("null RTV out-param".into()))?;
+
+        // Pre-bind the RTV for this output's lifetime, matching libvlc's
+        // own d3d11_player.cpp example: `select_plane_cb` leaves *output
+        // NULL so libvlc reuses what we bound here.
+        let rtvs = [Some(rtv.clone())];
+        unsafe {
+            self.context.OMSetRenderTargets(Some(&rtvs), None);
+        }
+
+        self.mailbox.push(OutputEvent {
+            handle,
+            width,
+            height,
+        });
+
+        let mut current = self.current.lock().expect("backend.current poisoned");
+        *current = Some(CurrentOutput { texture, rtv });
+        Ok(())
+    }
+
+}
+
+/// Register `Backend` with libvlc as the GPU output. Consumes one
+/// `Arc<Backend>` clone for libvlc's opaque pointer; `cleanup_cb` reclaims
+/// it. Caller keeps its own clone for the importer side.
+///
+/// Returns `Err` if `libvlc_video_set_output_callbacks` rejects the engine
+/// or callback set. On error the consumed Arc is reclaimed via `from_raw`
+/// before returning so the refcount stays correct.
+pub fn register(
+    player: *mut libvlc_media_player_t,
+    backend: Arc<Backend>,
+) -> Result<(), CallbackError> {
+    let raw = Arc::into_raw(backend) as *mut c_void;
+    let ok = unsafe {
+        libvlc_video_set_output_callbacks(
+            player,
+            libvlc_video_engine_t_libvlc_video_engine_d3d11,
+            Some(setup_cb),
+            Some(cleanup_cb),
+            None, // window_cb — unused
+            Some(update_output_cb),
+            Some(swap_cb),
+            Some(make_current_cb),
+            None, // getProcAddress_cb — OpenGL only
+            None, // metadata_cb — HDR only, not used in v1
+            Some(select_plane_cb),
+            raw,
+        )
+    };
+    if !ok {
+        unsafe {
+            let _ = Arc::from_raw(raw as *const Backend);
+        };
+        return Err(CallbackError::SetOutputCallbacksFailed);
+    }
+    Ok(())
+}
+
+unsafe fn backend_ref<'a>(opaque: *mut c_void) -> &'a Backend {
+    &*(opaque as *const Backend)
+}
+
+unsafe extern "C" fn setup_cb(
+    opaque: *mut *mut c_void,
+    _cfg: *const libvlc_video_setup_device_cfg_t,
+    out: *mut libvlc_video_setup_device_info_t,
+) -> bool {
+    if opaque.is_null() || (*opaque).is_null() || out.is_null() {
+        return false;
+    }
+    let backend = backend_ref(*opaque);
+    // context_mutex stays NULL: the immediate context is never touched
+    // outside libvlc's own callbacks.
+    (*out).__bindgen_anon_1.d3d11.device_context = backend.context.as_raw();
+    (*out).__bindgen_anon_1.d3d11.context_mutex = std::ptr::null_mut();
+    true
+}
+
+unsafe extern "C" fn cleanup_cb(opaque: *mut c_void) {
+    if opaque.is_null() {
+        return;
+    }
+    let _ = Arc::from_raw(opaque as *const Backend);
+}
+
+unsafe extern "C" fn update_output_cb(
+    opaque: *mut c_void,
+    cfg: *const libvlc_video_render_cfg_t,
+    output: *mut libvlc_video_output_cfg_t,
+) -> bool {
+    if opaque.is_null() || cfg.is_null() || output.is_null() {
+        return false;
+    }
+    let backend = backend_ref(opaque);
+    backend.update_output_calls.fetch_add(1, Ordering::SeqCst);
+    let width = (*cfg).width;
+    let height = (*cfg).height;
+    if width == 0 || height == 0 {
+        return false;
+    }
+    if let Err(e) = backend.rebuild_current_output(width, height) {
+        // godot_error! requires the main thread; we're on libvlc's. eprintln
+        // surfaces on the _console binary's stderr.
+        eprintln!("godot-vlc: update_output_cb rebuild failed: {e}");
+        return false;
+    }
+
+    // RGBA8 full-range BT.709 sRGB-transfer top-left, matching libvlc's own
+    // d3d11_player.cpp example.
+    (*output).__bindgen_anon_1.dxgi_format = DXGI_FORMAT_R8G8B8A8_UNORM_RAW;
+    (*output).full_range = true;
+    (*output).colorspace = libvlc_video_color_space_t_libvlc_video_colorspace_BT709;
+    (*output).primaries = libvlc_video_color_primaries_t_libvlc_video_primaries_BT709;
+    (*output).transfer = libvlc_video_transfer_func_t_libvlc_video_transfer_func_SRGB;
+    (*output).orientation = libvlc_video_orient_t_libvlc_video_orient_top_left;
+    true
+}
+
+unsafe extern "C" fn swap_cb(opaque: *mut c_void) {
+    if opaque.is_null() {
+        return;
+    }
+    let backend = backend_ref(opaque);
+    backend.swap_calls.fetch_add(1, Ordering::SeqCst);
+    if let Err(e) = backend.fence.signal_next(&backend.context) {
+        eprintln!("godot-vlc: swap_cb fence signal failed: {e}");
+    }
+}
+
+unsafe extern "C" fn make_current_cb(opaque: *mut c_void, _enter: bool) -> bool {
+    // Stub: RTV pre-bound in update_output_cb. Cannot be NULL — libvlc
+    // requires it for the d3d11 engine.
+    if !opaque.is_null() {
+        backend_ref(opaque).make_current_calls.fetch_add(1, Ordering::SeqCst);
+    }
+    true
+}
+
+unsafe extern "C" fn select_plane_cb(
+    _opaque: *mut c_void,
+    plane: usize,
+    _output: *mut c_void,
+) -> bool {
+    // Returning true with *output left unmodified makes libvlc reuse the
+    // RTV bound by update_output_cb. RGBA8 is single-plane.
+    plane == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dxgi_format_constant_matches_windows_rs() {
+        assert_eq!(
+            DXGI_FORMAT_R8G8B8A8_UNORM_RAW,
+            DXGI_FORMAT_R8G8B8A8_UNORM.0
+        );
+    }
+}

--- a/src/vlc_media_player/gpu_d3d11/private_queue.rs
+++ b/src/vlc_media_player/gpu_d3d11/private_queue.rs
@@ -1,0 +1,210 @@
+//! Private D3D12 command queue running the per-frame
+//! `Wait(imported_fence) → CopyResource → Signal(done_fence) → CPU-block`
+//! pipeline. Godot's main command queue is private in `RenderingDevice`
+//! with no GDExtension accessor, so we own a separate queue on the same
+//! `ID3D12Device` and CPU-block before Godot samples the destination.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use windows::core::Interface;
+use windows::Win32::Foundation::{CloseHandle, HANDLE, WAIT_OBJECT_0};
+use windows::Win32::Graphics::Direct3D12::{
+    ID3D12CommandAllocator, ID3D12CommandQueue, ID3D12Device, ID3D12Fence,
+    ID3D12GraphicsCommandList, ID3D12Resource, D3D12_COMMAND_LIST_TYPE_DIRECT,
+    D3D12_COMMAND_QUEUE_DESC, D3D12_COMMAND_QUEUE_FLAG_NONE, D3D12_COMMAND_QUEUE_PRIORITY_NORMAL,
+    D3D12_FENCE_FLAG_NONE, D3D12_RESOURCE_BARRIER, D3D12_RESOURCE_BARRIER_0,
+    D3D12_RESOURCE_BARRIER_FLAG_NONE, D3D12_RESOURCE_BARRIER_TYPE_TRANSITION,
+    D3D12_RESOURCE_STATES, D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_COPY_DEST,
+    D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_TRANSITION_BARRIER,
+    D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES,
+};
+use windows::Win32::System::Threading::{CreateEventW, WaitForSingleObject, INFINITE};
+
+#[derive(Debug)]
+pub enum PrivateQueueError {
+    CreateCommandQueue(String),
+    CreateCommandAllocator(String),
+    CreateCommandList(String),
+    CreateFence(String),
+    CreateEvent(String),
+    ResetAllocator(String),
+    ResetList(String),
+    CloseList(String),
+    SignalFence(String),
+    WaitFence(String),
+    SetEventOnCompletion(String),
+    EventWaitFailed(u32),
+}
+
+impl std::fmt::Display for PrivateQueueError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use PrivateQueueError::*;
+        match self {
+            CreateCommandQueue(s) => write!(f, "godot-vlc: CreateCommandQueue failed: {s}"),
+            CreateCommandAllocator(s) => {
+                write!(f, "godot-vlc: CreateCommandAllocator failed: {s}")
+            }
+            CreateCommandList(s) => write!(f, "godot-vlc: CreateCommandList failed: {s}"),
+            CreateFence(s) => write!(f, "godot-vlc: ID3D12Device::CreateFence failed: {s}"),
+            CreateEvent(s) => write!(f, "godot-vlc: CreateEventW failed: {s}"),
+            ResetAllocator(s) => {
+                write!(f, "godot-vlc: ID3D12CommandAllocator::Reset failed: {s}")
+            }
+            ResetList(s) => write!(f, "godot-vlc: ID3D12GraphicsCommandList::Reset failed: {s}"),
+            CloseList(s) => write!(f, "godot-vlc: ID3D12GraphicsCommandList::Close failed: {s}"),
+            SignalFence(s) => write!(f, "godot-vlc: ID3D12CommandQueue::Signal failed: {s}"),
+            WaitFence(s) => write!(f, "godot-vlc: ID3D12CommandQueue::Wait failed: {s}"),
+            SetEventOnCompletion(s) => {
+                write!(f, "godot-vlc: ID3D12Fence::SetEventOnCompletion failed: {s}")
+            }
+            EventWaitFailed(code) => {
+                write!(f, "godot-vlc: WaitForSingleObject returned {code:#x}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PrivateQueueError {}
+
+/// Direct command queue + allocator + list + completion fence + CPU wait
+/// event on Godot's `ID3D12Device`. Owns its own fence values so it can't
+/// race Godot's main queue.
+pub struct PrivateQueue {
+    queue: ID3D12CommandQueue,
+    allocator: ID3D12CommandAllocator,
+    list: ID3D12GraphicsCommandList,
+    done_fence: ID3D12Fence,
+    done_event: HANDLE,
+    next_value: AtomicU64,
+}
+
+unsafe impl Send for PrivateQueue {}
+unsafe impl Sync for PrivateQueue {}
+
+impl PrivateQueue {
+    pub fn create(device: &ID3D12Device) -> Result<Self, PrivateQueueError> {
+        let queue_desc = D3D12_COMMAND_QUEUE_DESC {
+            Type: D3D12_COMMAND_LIST_TYPE_DIRECT,
+            Priority: D3D12_COMMAND_QUEUE_PRIORITY_NORMAL.0,
+            Flags: D3D12_COMMAND_QUEUE_FLAG_NONE,
+            NodeMask: 0,
+        };
+        let queue: ID3D12CommandQueue = unsafe { device.CreateCommandQueue(&queue_desc) }
+            .map_err(|e| PrivateQueueError::CreateCommandQueue(e.message()))?;
+
+        let allocator: ID3D12CommandAllocator =
+            unsafe { device.CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT) }
+                .map_err(|e| PrivateQueueError::CreateCommandAllocator(e.message()))?;
+
+        let list: ID3D12GraphicsCommandList = unsafe {
+            device.CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, &allocator, None)
+        }
+        .map_err(|e| PrivateQueueError::CreateCommandList(e.message()))?;
+        unsafe { list.Close() }.map_err(|e| PrivateQueueError::CloseList(e.message()))?;
+
+        let done_fence: ID3D12Fence = unsafe { device.CreateFence(0, D3D12_FENCE_FLAG_NONE) }
+            .map_err(|e| PrivateQueueError::CreateFence(e.message()))?;
+
+        let done_event = unsafe { CreateEventW(None, false, false, None) }
+            .map_err(|e| PrivateQueueError::CreateEvent(e.message()))?;
+
+        Ok(Self {
+            queue,
+            allocator,
+            list,
+            done_fence,
+            done_event,
+            next_value: AtomicU64::new(0),
+        })
+    }
+
+    /// Wait `imported_fence` for `imported_value`, `CopyResource` src → dst,
+    /// signal our completion fence, then CPU-block until the copy lands.
+    /// Caller can safely sample `dst` after this returns.
+    pub fn copy_and_sync(
+        &self,
+        imported_fence: &ID3D12Fence,
+        imported_value: u64,
+        src: &ID3D12Resource,
+        dst: &ID3D12Resource,
+    ) -> Result<(), PrivateQueueError> {
+        unsafe {
+            self.allocator
+                .Reset()
+                .map_err(|e| PrivateQueueError::ResetAllocator(e.message()))?;
+            self.list
+                .Reset(&self.allocator, None)
+                .map_err(|e| PrivateQueueError::ResetList(e.message()))?;
+            // Round-trip COMMON ↔ COPY_SOURCE/COPY_DEST so the destination is
+            // back in COMMON when Godot's render graph next transitions it.
+            // Without this, Godot believes the texture is still in COMMON
+            // while the hardware is in COPY_DEST, the implicit transition on
+            // sample is invalid, and the GPU returns zeros.
+            let pre_barriers = [
+                transition_barrier(src, D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_COPY_SOURCE),
+                transition_barrier(dst, D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_COPY_DEST),
+            ];
+            self.list.ResourceBarrier(&pre_barriers);
+            self.list.CopyResource(dst, src);
+            let post_barriers = [
+                transition_barrier(src, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_COMMON),
+                transition_barrier(dst, D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_COMMON),
+            ];
+            self.list.ResourceBarrier(&post_barriers);
+            self.list
+                .Close()
+                .map_err(|e| PrivateQueueError::CloseList(e.message()))?;
+
+            self.queue
+                .Wait(imported_fence, imported_value)
+                .map_err(|e| PrivateQueueError::WaitFence(e.message()))?;
+
+            let list_for_exec: ID3D12GraphicsCommandList = self.list.clone();
+            let cmd_lists = [Some(list_for_exec.cast().unwrap())];
+            self.queue.ExecuteCommandLists(&cmd_lists);
+
+            let frame_value = self.next_value.fetch_add(1, Ordering::SeqCst) + 1;
+            self.queue
+                .Signal(&self.done_fence, frame_value)
+                .map_err(|e| PrivateQueueError::SignalFence(e.message()))?;
+
+            if self.done_fence.GetCompletedValue() < frame_value {
+                self.done_fence
+                    .SetEventOnCompletion(frame_value, self.done_event)
+                    .map_err(|e| PrivateQueueError::SetEventOnCompletion(e.message()))?;
+                let res = WaitForSingleObject(self.done_event, INFINITE);
+                if res != WAIT_OBJECT_0 {
+                    return Err(PrivateQueueError::EventWaitFailed(res.0));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn transition_barrier(
+    resource: &ID3D12Resource,
+    before: D3D12_RESOURCE_STATES,
+    after: D3D12_RESOURCE_STATES,
+) -> D3D12_RESOURCE_BARRIER {
+    D3D12_RESOURCE_BARRIER {
+        Type: D3D12_RESOURCE_BARRIER_TYPE_TRANSITION,
+        Flags: D3D12_RESOURCE_BARRIER_FLAG_NONE,
+        Anonymous: D3D12_RESOURCE_BARRIER_0 {
+            Transition: std::mem::ManuallyDrop::new(D3D12_RESOURCE_TRANSITION_BARRIER {
+                pResource: std::mem::ManuallyDrop::new(Some(resource.clone())),
+                Subresource: D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES,
+                StateBefore: before,
+                StateAfter: after,
+            }),
+        },
+    }
+}
+
+impl Drop for PrivateQueue {
+    fn drop(&mut self) {
+        if !self.done_event.is_invalid() {
+            unsafe { _ = CloseHandle(self.done_event) };
+        }
+    }
+}

--- a/src/vlc_media_player/gpu_d3d11/rd_import.rs
+++ b/src/vlc_media_player/gpu_d3d11/rd_import.rs
@@ -1,0 +1,101 @@
+//! Open shared NT handles on Godot's D3D12 device and recover the
+//! underlying `ID3D12Resource*` from an RD-allocated texture.
+
+use std::ffi::c_void;
+
+use godot::classes::rendering_device::DriverResource;
+use godot::classes::RenderingServer;
+use godot::prelude::*;
+
+use windows::core::Interface;
+use windows::Win32::Foundation::HANDLE;
+use windows::Win32::Graphics::Direct3D12::{ID3D12Device, ID3D12Fence, ID3D12Resource};
+
+#[derive(Debug)]
+pub enum ImportError {
+    NoRenderingDevice,
+    NoLogicalDevice,
+    OpenSharedHandle(String),
+    NoNativeTextureHandle,
+}
+
+impl std::fmt::Display for ImportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoRenderingDevice => write!(f, "godot-vlc: no Godot RenderingDevice"),
+            Self::NoLogicalDevice => write!(
+                f,
+                "godot-vlc: Godot returned no D3D12 logical device handle"
+            ),
+            Self::OpenSharedHandle(s) => {
+                write!(f, "godot-vlc: D3D12 OpenSharedHandle failed: {s}")
+            }
+            Self::NoNativeTextureHandle => write!(
+                f,
+                "godot-vlc: get_driver_resource(TEXTURE_VIEW) returned 0 (RID invalid?)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ImportError {}
+
+/// Godot's `ID3D12Device`, AddRef'd. Caller's Drop will Release.
+pub fn godot_d3d12_device() -> Result<ID3D12Device, ImportError> {
+    let mut rd = RenderingServer::singleton()
+        .get_rendering_device()
+        .ok_or(ImportError::NoRenderingDevice)?;
+    let raw_handle = rd.get_driver_resource(DriverResource::LOGICAL_DEVICE, Rid::Invalid, 0);
+    if raw_handle == 0 {
+        return Err(ImportError::NoLogicalDevice);
+    }
+    let raw = raw_handle as *mut c_void;
+    unsafe {
+        let borrowed =
+            ID3D12Device::from_raw_borrowed(&raw).ok_or(ImportError::NoLogicalDevice)?;
+        Ok(borrowed.clone())
+    }
+}
+
+pub fn open_shared_texture(
+    device: &ID3D12Device,
+    handle: HANDLE,
+) -> Result<ID3D12Resource, ImportError> {
+    let mut resource: Option<ID3D12Resource> = None;
+    unsafe { device.OpenSharedHandle(handle, &mut resource) }
+        .map_err(|e| ImportError::OpenSharedHandle(e.message()))?;
+    resource.ok_or_else(|| ImportError::OpenSharedHandle("null resource out-param".into()))
+}
+
+pub fn open_shared_fence(
+    device: &ID3D12Device,
+    handle: HANDLE,
+) -> Result<ID3D12Fence, ImportError> {
+    let mut fence: Option<ID3D12Fence> = None;
+    unsafe { device.OpenSharedHandle(handle, &mut fence) }
+        .map_err(|e| ImportError::OpenSharedHandle(e.message()))?;
+    fence.ok_or_else(|| ImportError::OpenSharedHandle("null fence out-param".into()))
+}
+
+/// Native `ID3D12Resource*` for a Godot-allocated RD texture, AddRef'd.
+///
+/// Uses `DRIVER_RESOURCE_TEXTURE_VIEW`, not `TEXTURE`: on Godot 4.5.2's
+/// D3D12 driver `TEXTURE` returns `tex_info->main_texture`, which is null
+/// for plain `texture_create()` allocations (only set for sliced/shared
+/// views). `TEXTURE_VIEW` returns `tex_info->resource` and works on both
+/// 4.5.2 and 4.7+.
+pub fn godot_rd_texture_native(rid: Rid) -> Result<ID3D12Resource, ImportError> {
+    let mut rd = RenderingServer::singleton()
+        .get_rendering_device()
+        .ok_or(ImportError::NoRenderingDevice)?;
+    let raw_handle = rd.get_driver_resource(DriverResource::TEXTURE_VIEW, rid, 0);
+    if raw_handle == 0 {
+        return Err(ImportError::NoNativeTextureHandle);
+    }
+    let raw = raw_handle as *mut c_void;
+    unsafe {
+        let borrowed =
+            ID3D12Resource::from_raw_borrowed(&raw).ok_or(ImportError::NoNativeTextureHandle)?;
+        Ok(borrowed.clone())
+    }
+}

--- a/src/vlc_media_player/gpu_d3d11/shared_texture.rs
+++ b/src/vlc_media_player/gpu_d3d11/shared_texture.rs
@@ -1,0 +1,85 @@
+//! `ID3D11Fence` shareable as an NT handle. D3D11 signals after writes,
+//! D3D12 waits before sampling, monotonic value tracked in an atomic.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use windows::core::Interface;
+use windows::Win32::Foundation::{CloseHandle, GENERIC_ALL, HANDLE};
+use windows::Win32::Graphics::Direct3D11::{
+    ID3D11Device, ID3D11Device5, ID3D11DeviceContext, ID3D11DeviceContext4, ID3D11Fence,
+    D3D11_FENCE_FLAG_SHARED,
+};
+
+#[derive(Debug)]
+pub enum SharedError {
+    CreateSharedHandle(String),
+    Device5Cast(String),
+    DeviceContext4Cast(String),
+    CreateFence(String),
+    SignalFence(String),
+}
+
+impl std::fmt::Display for SharedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CreateSharedHandle(s) => write!(f, "godot-vlc: CreateSharedHandle failed: {s}"),
+            Self::Device5Cast(s) => write!(f, "godot-vlc: cast to ID3D11Device5 failed: {s}"),
+            Self::DeviceContext4Cast(s) => {
+                write!(f, "godot-vlc: cast to ID3D11DeviceContext4 failed: {s}")
+            }
+            Self::CreateFence(s) => write!(f, "godot-vlc: ID3D11Device5::CreateFence failed: {s}"),
+            Self::SignalFence(s) => write!(f, "godot-vlc: ID3D11DeviceContext4::Signal failed: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for SharedError {}
+
+pub struct SharedFence {
+    pub fence: ID3D11Fence,
+    pub shared_handle: HANDLE,
+    pub signaled_value: AtomicU64,
+}
+
+impl SharedFence {
+    pub fn create(device: &ID3D11Device) -> Result<Self, SharedError> {
+        let device5: ID3D11Device5 = device
+            .cast()
+            .map_err(|e| SharedError::Device5Cast(e.message()))?;
+        let mut fence: Option<ID3D11Fence> = None;
+        unsafe { device5.CreateFence(0, D3D11_FENCE_FLAG_SHARED, &mut fence) }
+            .map_err(|e| SharedError::CreateFence(e.message()))?;
+        let fence = fence
+            .ok_or_else(|| SharedError::CreateFence("null fence out-param".into()))?;
+        let handle = unsafe { fence.CreateSharedHandle(None, GENERIC_ALL.0, None) }
+            .map_err(|e| SharedError::CreateSharedHandle(e.message()))?;
+        Ok(Self {
+            fence,
+            shared_handle: handle,
+            signaled_value: AtomicU64::new(0),
+        })
+    }
+
+    /// Bump and signal the next fence value. D3D12 side waits on this.
+    pub fn signal_next(&self, ctx: &ID3D11DeviceContext) -> Result<u64, SharedError> {
+        let ctx4: ID3D11DeviceContext4 = ctx
+            .cast()
+            .map_err(|e| SharedError::DeviceContext4Cast(e.message()))?;
+        let next = self.signaled_value.fetch_add(1, Ordering::SeqCst) + 1;
+        unsafe { ctx4.Signal(&self.fence, next) }
+            .map_err(|e| SharedError::SignalFence(e.message()))?;
+        Ok(next)
+    }
+
+    pub fn current(&self) -> u64 {
+        self.signaled_value.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for SharedFence {
+    fn drop(&mut self) {
+        if !self.shared_handle.is_invalid() {
+            unsafe { _ = CloseHandle(self.shared_handle) };
+        }
+    }
+}

--- a/src/vlc_media_player/software_video.rs
+++ b/src/vlc_media_player/software_video.rs
@@ -1,0 +1,120 @@
+/*
+* Copyright (c) 2025 xiSage
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this library; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+* USA
+*/
+
+use std::{
+    ffi::{c_char, c_uint, c_void},
+    ptr,
+    sync::mpsc,
+};
+
+use godot::{
+    classes::{image, Image},
+    prelude::*,
+};
+
+pub(super) unsafe extern "C" fn video_lock_callback(
+    opaque: *mut c_void,
+    planes: *mut *mut c_void,
+) -> *mut c_void {
+    let (_tx, _img, buffer) = (opaque
+        as *mut (
+            *mut mpsc::Sender<(bool, Gd<Image>)>,
+            Gd<Image>,
+            PackedByteArray,
+        ))
+        .as_mut()
+        .unwrap();
+    let buffer_ptr = buffer.as_mut_slice().as_mut_ptr();
+    *planes = buffer_ptr as *mut c_void;
+    ptr::null_mut()
+}
+
+pub(super) unsafe extern "C" fn video_unlock_callback(
+    opaque: *mut c_void,
+    _picture: *mut c_void,
+    _planes: *const *mut c_void,
+) {
+    let (_tx, img, buffer) = (opaque
+        as *mut (
+            *mut mpsc::Sender<(bool, Gd<Image>)>,
+            Gd<Image>,
+            PackedByteArray,
+        ))
+        .as_mut()
+        .unwrap();
+    let width = img.get_width();
+    let height = img.get_height();
+    let format = img.get_format();
+    img.set_data(width, height, false, format, buffer);
+}
+
+pub(super) unsafe extern "C" fn video_display_callback(
+    opaque: *mut c_void,
+    _picture: *mut c_void,
+) {
+    let (tx, img, _buffer) = (opaque
+        as *mut (
+            *mut mpsc::Sender<(bool, Gd<Image>)>,
+            Gd<Image>,
+            PackedByteArray,
+        ))
+        .as_mut()
+        .unwrap();
+    _ = tx
+        .as_mut()
+        .unwrap()
+        .send((false, img.duplicate().unwrap().cast()));
+}
+
+pub(super) unsafe extern "C" fn video_format_callback(
+    opaque: *mut *mut c_void,
+    chroma: *mut c_char,
+    width: *mut c_uint,
+    height: *mut c_uint,
+    pitches: *mut c_uint,
+    lines: *mut c_uint,
+) -> c_uint {
+    let tx: *mut mpsc::Sender<(bool, Gd<Image>)> = *opaque as *mut mpsc::Sender<(bool, Gd<Image>)>;
+    let img = match Image::create_empty(*width as i32, *height as i32, false, image::Format::RGB8) {
+        Some(img) => img,
+        None => {
+            return 0;
+        }
+    };
+    let buffer = img.get_data();
+    chroma.copy_from(c"RV24".as_ptr(), 5);
+    *pitches = *width * 3;
+    *lines = *height;
+    if tx.as_mut().unwrap().send((true, img.clone())).is_err() {
+        return 0;
+    }
+    *opaque = Box::into_raw(Box::new((tx, img, buffer))) as *mut c_void;
+    1
+}
+
+pub(super) unsafe extern "C" fn video_cleanup_callback(opaque: *mut c_void) {
+    let (_tx, _img, _buffer) = *Box::from_raw(
+        opaque
+            as *mut (
+                *mut mpsc::Sender<(bool, Gd<Image>)>,
+                Gd<Image>,
+                PackedByteArray,
+            ),
+    );
+}

--- a/thirdparty/vlc/include/vlc/libvlc_media_player.h
+++ b/thirdparty/vlc/include/vlc/libvlc_media_player.h
@@ -626,6 +626,14 @@ typedef struct libvlc_video_output_cfg_t
         int opengl_format;
         /** currently unused */
         void *p_surface;
+        struct {
+            /** Pointer to an ANativeWindow, used for video rendering */
+            void *video;
+            /** Pointer to an ANativeWindow, used for subtitles rendering, if
+             * blending subtitles into the video surface is not possible (when
+             * using MediaCodec with direct hw rendering) */
+            void *subtitle;
+        } anw;
     };
     /** Video is full range or studio/limited range. */
     bool full_range;
@@ -652,9 +660,9 @@ typedef struct libvlc_video_output_cfg_t
  *       uses to render. The host must set a Render target and call Present()
  *       when it needs the drawing from VLC to be done. This object is not valid
  *       anymore after Cleanup is called.
- *
- * Tone mapping, range and color conversion will be done depending on the values
- * set in the output structure.
+ * Tone mapping, range and color conversion will be done depending on the
+ * values set in the output structure. It can be ignored in the \ref
+ * libvlc_video_engine_anw case.
  */
 typedef bool (*libvlc_video_update_output_cb)(void* opaque, const libvlc_video_render_cfg_t *cfg,
                                               libvlc_video_output_cfg_t *output );
@@ -709,15 +717,15 @@ typedef void* (*libvlc_video_getProcAddress_cb)(void* opaque, const char* fct_na
 
 typedef struct libvlc_video_frame_hdr10_metadata_t
 {
-    /* similar to SMPTE ST 2086 mastering display color volume */
-    uint16_t RedPrimary[2];
-    uint16_t GreenPrimary[2];
-    uint16_t BluePrimary[2];
-    uint16_t WhitePoint[2];
-    unsigned int MaxMasteringLuminance;
-    unsigned int MinMasteringLuminance;
-    uint16_t MaxContentLightLevel;
-    uint16_t MaxFrameAverageLightLevel;
+    /* similar to CTA-861-G with ranges from H265, based on SMPTE ST 2086 mastering display color volume */
+    uint16_t RedPrimary[2];   /**< [5,37 000] normalized x / [5,42 000] y chromacity in increments of 0.00002, 0=unknown */
+    uint16_t GreenPrimary[2]; /**< [5,37 000] normalized x / [5,42 000] y chromacity in increments of 0.00002, 0=unknown */
+    uint16_t BluePrimary[2];  /**< [5,37 000] normalized x / [5,42 000] y chromacity in increments of 0.00002, 0=unknown */
+    uint16_t WhitePoint[2];   /**< [5,37 000] normalized x / [5,42 000] y white point in increments of 0.00002, 0=unknown */
+    unsigned int MaxMasteringLuminance; /**< [50 000, 100 000 000] maximum luminance in 0.0001 cd/m², 0=unknown */
+    unsigned int MinMasteringLuminance; /**< [1, 50 000] minimum luminance in 0.0001 cd/m², 0=unknown */
+    uint16_t MaxContentLightLevel;      /**< [1, 50 000] Maximum Content Light Level in cd/m², 0=unknown */
+    uint16_t MaxFrameAverageLightLevel; /**< [1, 50 000] Maximum Frame-Average Light Level in cd/m², 0=unknown */
 } libvlc_video_frame_hdr10_metadata_t;
 
 typedef enum libvlc_video_metadata_type_t {
@@ -747,6 +755,23 @@ typedef enum libvlc_video_engine_t {
     libvlc_video_engine_d3d11,
     /** Direct3D9 rendering engine */
     libvlc_video_engine_d3d9,
+
+    /**
+     * Android ANativeWindow. It can be set in \ref libvlc_video_output_cfg_t
+     * from the \ref libvlc_video_update_output_cb callback. The ANativeWindow
+     * can be created via:
+     *  - 'ANativeWindow_fromSurface': from a JAVA SurfaceView
+     *  - 'AImageReader_getWindow()': from an 'AImageReader' created with the
+     *  following arguments: \verbatim
+     AImageReader_newWithUsage(1, 1 AIMAGE_FORMAT_PRIVATE,
+                               AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE,
+                               maxImages, &reader);
+     \endverbatim
+     * The width and height from \ref libvlc_video_render_cfg_t should be
+     * ignored as the video size is overridden by the producer (MediaCodec or
+     * EGL vout).
+     */
+    libvlc_video_engine_anw,
 } libvlc_video_engine_t;
 
 
@@ -876,9 +901,12 @@ typedef bool( *libvlc_video_output_select_plane_cb )( void *opaque, size_t plane
  * \param cleanup_cb callback called to clean up user data
  * \param window_cb callback called to setup the window
  * \param update_output_cb callback to get the rendering format of the host (cannot be NULL)
- * \param swap_cb callback called after rendering a video frame (cannot be NULL)
- * \param makeCurrent_cb callback called to enter/leave the rendering context (cannot be NULL)
- * \param getProcAddress_cb opengl function loading callback (cannot be NULL for \ref libvlc_video_engine_opengl and for \ref libvlc_video_engine_gles2)
+ * \param swap_cb callback called after rendering a video frame (can only be
+ * NULL when using \ref libvlc_video_engine_anw)
+ * \param makeCurrent_cb callback called to enter/leave the rendering context
+ * (can only be NULL when using \ref libvlc_video_engine_anw)
+ * \param getProcAddress_cb opengl function loading callback (cannot be NULL
+ * for \ref libvlc_video_engine_opengl and for \ref libvlc_video_engine_gles2)
  * \param metadata_cb callback to provide frame metadata (D3D11 only)
  * \param select_plane_cb callback to select different D3D11 rendering targets
  * \param opaque private pointer passed to callbacks
@@ -905,6 +933,22 @@ bool libvlc_video_set_output_callbacks( libvlc_media_player_t *mp,
                                         void* opaque );
 
 /**
+ * Helper to setup output_callbacks for \ref libvlc_video_engine_anw
+ */
+static inline bool
+libvlc_video_set_anw_callbacks( libvlc_media_player_t *mp,
+                                libvlc_video_output_setup_cb setup_cb,
+                                libvlc_video_output_cleanup_cb cleanup_cb,
+                                libvlc_video_update_output_cb update_output_cb,
+                                void *opaque )
+{
+    return libvlc_video_set_output_callbacks( mp, libvlc_video_engine_anw,
+                                              setup_cb, cleanup_cb, NULL,
+                                              update_output_cb, NULL, NULL,
+                                              NULL, NULL, NULL, opaque );
+}
+
+/**
  * Set the handler where the media player should display its video output.
  *
  * The drawable is an `NSObject` that require responding to two selectors
@@ -921,10 +965,10 @@ bool libvlc_video_set_output_callbacks( libvlc_media_player_t *mp,
  * class.
  * VLCDrawable protocol conformance isn't mandatory but a drawable must respond
  * to both `addSubview:` and `bounds` selectors.
- * 
+ *
  * Additionally, a drawable can also conform to the `VLCPictureInPictureDrawable`
  * protocol to allow picture in picture support :
- * 
+ *
  * @code{.m}
  * @protocol VLCPictureInPictureMediaControlling <NSObject>
  * - (void)play;
@@ -935,23 +979,23 @@ bool libvlc_video_set_output_callbacks( libvlc_media_player_t *mp,
  * - (BOOL)isMediaSeekable;
  * - (BOOL)isMediaPlaying;
  * @end
- * 
+ *
  * @protocol VLCPictureInPictureWindowControlling <NSObject>
  * - (void)startPictureInPicture;
  * - (void)stopPictureInPicture;
  * - (void)invalidatePlaybackState;
  * @end
- * 
+ *
  * @protocol VLCPictureInPictureDrawable <NSObject>
  * - (id<VLCPictureInPictureMediaControlling>) mediaController;
  * - (void (^)(id<VLCPictureInPictureWindowControlling>)) pictureInPictureReady;
  * @end
  * @endcode
- * 
+ *
  * Be aware that full `VLCPictureInPictureDrawable` conformance is mandatory to
  * enable picture in picture support and that time values in
  * `VLCPictureInPictureMediaControlling` methods are expressed in milliseconds.
- * 
+ *
  * If you want to use it along with Qt see the QMacCocoaViewContainer. Then
  * the following code should work:
  * @code{.mm}
@@ -966,7 +1010,7 @@ bool libvlc_video_set_output_callbacks( libvlc_media_player_t *mp,
  * You can find a live example in VLCVideoView in VLCKit.framework.
  *
  * \param p_mi the Media Player
- * \param drawable the drawable that is either an NSView, a UIView or any 
+ * \param drawable the drawable that is either an NSView, a UIView or any
  * NSObject responding to `addSubview:` and `bounds` selectors
  */
 LIBVLC_API void libvlc_media_player_set_nsobject ( libvlc_media_player_t *p_mi, void * drawable );
@@ -2010,7 +2054,7 @@ LIBVLC_API char *libvlc_video_get_aspect_ratio( libvlc_media_player_t *p_mi );
  * Set new video aspect ratio.
  *
  * \param p_mi the media player
- * \param psz_aspect new video aspect-ratio or NULL to reset to source aspect ratio
+ * \param psz_aspect new video aspect-ratio, "fill" to fill the window or NULL to reset to source aspect ratio
  * \note Invalid aspect ratios are ignored.
  */
 LIBVLC_API void libvlc_video_set_aspect_ratio( libvlc_media_player_t *p_mi, const char *psz_aspect );
@@ -2343,14 +2387,33 @@ int libvlc_video_take_snapshot( libvlc_media_player_t *p_mi, unsigned num,
                                 unsigned int i_height );
 
 /**
+ * Gets the deinterlacing parameters.
+ *
+ * If \p modep is not NULL, it will be set to a heap-allocated nul-terminated
+ * character string indicating the current deinterlacing algorithm name.
+ * If no algorithm is selected or if allocation fails, it be set to NULL.
+ * The value should be freed with the C run-time's free() function to avoid
+ * leaking.
+ *
+ * \param mpi media player instance
+ * \param modep storage space for hold the mode name (or NULL) [OUT]
+ * \retval -1 deinterlacing is selected automatically
+ * \retval 0 deinterlacing is forcefully disabled
+ * \retval 1 deinterlacing is forcefully enabled
+ */
+LIBVLC_API int libvlc_video_get_deinterlace(libvlc_media_player_t *mp,
+                                            char **modep);
+
+/**
  * Enable or disable deinterlace filter
  *
  * \param p_mi libvlc media player
  * \param deinterlace state -1: auto (default), 0: disabled, 1: enabled
  * \param psz_mode type of deinterlace filter, NULL for current/default filter
  * \version LibVLC 4.0.0 and later
+ * \return 0 on success, -1 if the mode was not recognised
  */
-LIBVLC_API void libvlc_video_set_deinterlace( libvlc_media_player_t *p_mi,
+LIBVLC_API int libvlc_video_set_deinterlace( libvlc_media_player_t *p_mi,
                                               int deinterlace,
                                               const char *psz_mode );
 


### PR DESCRIPTION
Adds a `force_hardware` toggle on `VLCMediaPlayer`. When enabled on
  Windows under `--rendering-driver d3d12`, libvlc decodes (D3D11VA
  hardware) and renders into a shared D3D11 texture; a private D3D12
  queue copies that texture into a Godot `Texture2DRD` each frame. No
  CPU pixel traffic. The existing software path is unchanged and stays
  the default; on any prerequisite failure the player logs an error and
  falls back to it per-player.

  It's GPU-copy, not zero-copy: stock Godot 4.5.2 doesn't expose its
  main D3D12 queue, doesn't bind `driver_callback_add` through
  GDExtension, and `texture_create_from_extension` rejects views over
  imported textures in editor / debug builds. True zero-copy is gated
  on upstream Godot patches.

  Also syncs the bundled libvlc SDK header to match the binary's ABI
  (upstream had added a 16-byte `anw` struct to `libvlc_video_output_cfg_t`'s
  union, shifting field offsets), and pins the Rust toolchain to 1.91.0
  (`godot-core 0.3.5` hits a 1.92+ debug-only compile bug).

  Not in scope: Linux/macOS, Vulkan on Windows, HDR passthrough.